### PR TITLE
Ch2923/fix unit tests

### DIFF
--- a/src/AwsJanitor.WebApi.Tests/Builders/HttpClientBuilder.cs
+++ b/src/AwsJanitor.WebApi.Tests/Builders/HttpClientBuilder.cs
@@ -31,7 +31,7 @@ namespace AwsJanitor.WebApi.Tests.Builders
         {
             return new WebHostBuilder()
                 .UseStartup<Startup>()
-                .ConfigureTestServices(services =>
+                .ConfigureServices(services =>
                 {
                     _serviceDescriptors
                         .Values

--- a/src/AwsJanitor.WebApi.Tests/Controllers/ConfigControllerFacts.cs
+++ b/src/AwsJanitor.WebApi.Tests/Controllers/ConfigControllerFacts.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Threading.Tasks;
+using Amazon.SecurityToken;
 using AwsJanitor.WebApi.Controllers;
 using AwsJanitor.WebApi.Infrastructure.Aws;
 using AwsJanitor.WebApi.Tests.Builders;
@@ -31,6 +32,7 @@ namespace AwsJanitor.WebApi.Tests.Controllers
 
                 var client = builder
                     .WithService<IParameterStore>(new ParameterStoreStub(dummyContent))
+                    .WithService<IAmazonSecurityTokenService>(new AmazonSecurityTokenServiceStub())
                     .Build();
 
                 var response = await client.GetAsync("api/configs/kubeconfig");

--- a/src/AwsJanitor.WebApi.Tests/Controllers/RoleControllerFacts/CreateFacts.cs
+++ b/src/AwsJanitor.WebApi.Tests/Controllers/RoleControllerFacts/CreateFacts.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Threading.Tasks;
 using Amazon;
@@ -22,6 +21,7 @@ namespace AwsJanitor.WebApi.Tests.Controllers.RoleControllerFacts
                 // Arrange
                 var client = builder
                     .WithService<ICreateIAMRoleRequestValidator>(new CreateIAMRoleRequestValidatorStub(false))
+                    .WithService<IAwsIdentityCommandClient>(new AwsIdentityCommandClientStub())
                     .WithService(RegionEndpoint.CNNorth1)
                     .Build();
 
@@ -51,6 +51,7 @@ namespace AwsJanitor.WebApi.Tests.Controllers.RoleControllerFacts
                 var client = builder
                     .WithService<ICreateIAMRoleRequestValidator>(new CreateIAMRoleRequestValidatorStub(true))
                     .WithService<IAwsIdentityCommandClient>(new AwsIdentityCommandClientStub())
+                    .WithService<IParameterStore>(new ParameterStoreStub(null))
                     .WithService(RegionEndpoint.CNNorth1)
                     .Build();
 

--- a/src/AwsJanitor.WebApi/Features/Roles/RolesServicesConfiguration.cs
+++ b/src/AwsJanitor.WebApi/Features/Roles/RolesServicesConfiguration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Amazon;
 using Amazon.IdentityManagement;
 using AwsJanitor.WebApi.Features.Roles.Infrastructure;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace AwsJanitor.WebApi.Features.Roles
 {
@@ -13,7 +14,7 @@ namespace AwsJanitor.WebApi.Features.Roles
         public static void ConfigureServices(IServiceCollection services)
         {
            
-            services.AddTransient<IAmazonSecurityTokenService>(serviceProvider => new AmazonSecurityTokenServiceClient(
+            services.TryAddTransient<IAmazonSecurityTokenService>(serviceProvider => new AmazonSecurityTokenServiceClient(
                 region: serviceProvider.GetRequiredService<RegionEndpoint>()
             ));
 
@@ -23,10 +24,10 @@ namespace AwsJanitor.WebApi.Features.Roles
 
             services.AddTransient<IIdentityManagementServiceClient, IdentityManagementServiceClient>();
             
-            services.AddTransient<IAwsIdentityCommandClient, AwsIdentityCommandClient>();
+            services.TryAddTransient<IAwsIdentityCommandClient, AwsIdentityCommandClient>();
 
             
-            services.AddTransient<ICreateIAMRoleRequestValidator, CreateIAMRoleRequestValidator>();
+            services.TryAddTransient<ICreateIAMRoleRequestValidator, CreateIAMRoleRequestValidator>();
 
             services.AddTransient<IAwsIdentityQueryClient, AwsIdentityQueryClient>();
             

--- a/src/AwsJanitor.WebApi/Startup.cs
+++ b/src/AwsJanitor.WebApi/Startup.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AwsJanitor.WebApi.Controllers;
 using AwsJanitor.WebApi.Domain.Events;
 using AwsJanitor.WebApi.EventHandlers;
 using AwsJanitor.WebApi.Features.Roles;
+using AwsJanitor.WebApi.Infrastructure.Aws;
 using AwsJanitor.WebApi.Infrastructure.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -47,10 +49,13 @@ namespace AwsJanitor.WebApi
                 c.EnableAnnotations();
             });
 
-
+            
             RolesServicesConfiguration.ConfigureServices(services);
-
-            ParameterStoreServicesConfiguration.ConfigureServices(Configuration, services);
+            if (services.Any(s => typeof(IParameterStore).IsAssignableFrom(s.ServiceType)) == false)
+            {
+                ParameterStoreServicesConfiguration.ConfigureServices(Configuration, services);
+            }
+     
 
             services.AddHostedService<MetricHostedService>();
 


### PR DESCRIPTION
Changed the order of who registers service in the dependency container.
Now services added by test will be registered first, then services in the main assembly setup file.
 
This allows us to register a service in a test and not register the service in startup if the given service is already registered.

With this change we can negate the issue where tests require a configuration for a service that should not call third party.  